### PR TITLE
Update name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "GoogleMaps quick demo",
+  "name": "GoogleMaps-quick-demo",
   "version": "0.0.1",
   "author": "Masashi Katsumata",
   "homepage": "https://github.com/mapsplugin",


### PR DESCRIPTION
`npm install` is not working out-of-the box because of the name in `package.json`.

This PR adds hyphens to the name to solve that.